### PR TITLE
fix bug: branching at a node with null swipe_id created broken chat

### DIFF
--- a/index.js
+++ b/index.js
@@ -1781,7 +1781,9 @@ function processTimelinesHotkeys(event) {
         closeModal();
         closeTapTippy();
         closeTippy();
-        resetLegendHighlight(theCy);  // Reset the legend highlight state
-        restoreElements(theCy);  // Remove remaining highlights, if any (from text search, and edge highlighting)
+        if (theCy) {
+            resetLegendHighlight(theCy);  // Reset the legend highlight state
+            restoreElements(theCy);  // Remove remaining highlights, if any (from text search, and edge highlighting)
+        }
     }
 }

--- a/index.js
+++ b/index.js
@@ -860,29 +860,30 @@ function filterElementsAndPad(cy, selector) {
         eles = cy.filter();  // zoom out (select all elements) if no selector (empty query)
     } else {
         eles = cy.filter(selector);
-        if (eles.length > 0) {
-            const zoomToFit = calculateFitZoom(cy, eles);
-            if (zoomToFit >= 1.0) {
-                // Compute the size of one node, in rendered pixels, at the zoom level that would be required to fit the selected content exactly.
-                const nodeWidthRendered = zoomToFit * extension_settings.timeline.nodeWidth;
-                const nodeHeightRendered = zoomToFit * extension_settings.timeline.nodeHeight;
-                padding = Math.min(nodeWidthRendered, nodeHeightRendered);  // arbitrary, but maybe better than max
-
-                // Limit padding so that at least one node always fits into the viewport, regardless of how far in we try to zoom.
-                // This prevents the graph from zooming out due to an insane theoretical amount of padding (more than viewport size)
-                // when the auto-zoom zooms in really close.
-                //
-                // In practice: if one node would take >= 34% of horizontal or vertical viewport space, reserve 33% of the smaller
-                // viewport dimension for padding on each side, to clamp the size of one node along that dimension to at most 34%.
-                // This limits the size of one node to ~one third of the viewport size.
-                const view_w = cy.width();
-                const view_h = cy.height();
-                if ((nodeWidthRendered >= 0.34 * view_w) || (nodeHeightRendered >= 0.34 * view_h)) {
-                    padding = Math.min(0.33 * view_w, 0.33 * view_h);
-                }
-            }
-        } else {
+        if (eles.length === 0) {
             eles = cy.filter();  // zoom out (select all elements) if the selector didn't match
+        }
+    }
+    if (eles.length > 0) {  // if the graph is not empty
+        const zoomToFit = calculateFitZoom(cy, eles);
+        if (zoomToFit >= 1.0) {
+            // Compute the size of one node, in rendered pixels, at the zoom level that would be required to fit the selected content exactly.
+            const nodeWidthRendered = zoomToFit * extension_settings.timeline.nodeWidth;
+            const nodeHeightRendered = zoomToFit * extension_settings.timeline.nodeHeight;
+            padding = Math.min(nodeWidthRendered, nodeHeightRendered);  // arbitrary, but maybe better than max
+
+            // Limit padding so that at least one node always fits into the viewport, regardless of how far in we try to zoom.
+            // This prevents the graph from zooming out due to an insane theoretical amount of padding (more than viewport size)
+            // when the auto-zoom zooms in really close.
+            //
+            // In practice: if one node would take >= 34% of horizontal or vertical viewport space, reserve 33% of the smaller
+            // viewport dimension for padding on each side, to clamp the size of one node along that dimension to at most 34%.
+            // This limits the size of one node to ~one third of the viewport size.
+            const view_w = cy.width();
+            const view_h = cy.height();
+            if ((nodeWidthRendered >= 0.34 * view_w) || (nodeHeightRendered >= 0.34 * view_h)) {
+                padding = Math.min(0.33 * view_w, 0.33 * view_h);
+            }
         }
     }
     return [eles, padding]

--- a/index.js
+++ b/index.js
@@ -1578,30 +1578,32 @@ function flashNode(node, howManyFlashes, duration) {
  * @returns {Promise<void>}
  */
 async function onTimelineButtonClick() {
-    showLoader();
+    let dataUpdated = false;
     try {
-        const dataUpdated = await updateTimelineDataIfNeeded();
-        handleModalDisplay();  // Show the timeline view, and wire the close button to close it.
-        if (dataUpdated) {
-            renderCytoscapeDiagram(lastTimelineData);  // after this, the Cytoscape instance `theCy` is alive
-            toggleSwipes(theCy, extension_settings.timeline.autoExpandSwipes);
-        }
-        closeOpenDrawers();
-
-        // Let the window layout settle itself for 500 ms before trying to zoom
-        // (this avoids some failed pans/zooms).
-        setTimeout(() => {
-            let textSearchElement = document.getElementById('transparent-search');
-            textSearchElement.focus();
-            textSearchElement.select();  // select content for easy erasing
-            zoomToCurrentChatNode(theCy);  // override the zoom-to-search
-            // textSearchElement.dispatchEvent(new Event('input'));  // no need to trigger input event to perform search, since now focusing the element already searches
-        }, 500);
+        showLoader();
+        dataUpdated = await updateTimelineDataIfNeeded();
     }
     finally {
         await delay(1);  // This avoids the loading screen getting stuck when there is no need to update the data.
         hideLoader();
     }
+
+    handleModalDisplay();  // Show the timeline view, and wire the close button to close it.
+    if (dataUpdated) {
+        renderCytoscapeDiagram(lastTimelineData);  // after this, the Cytoscape instance `theCy` is alive
+        toggleSwipes(theCy, extension_settings.timeline.autoExpandSwipes);
+    }
+    closeOpenDrawers();
+
+    // Let the window layout settle itself for 500 ms before trying to zoom
+    // (this avoids some failed pans/zooms).
+    setTimeout(() => {
+        let textSearchElement = document.getElementById('transparent-search');
+        textSearchElement.focus();
+        textSearchElement.select();  // select content for easy erasing
+        zoomToCurrentChatNode(theCy);  // override the zoom-to-search
+        // textSearchElement.dispatchEvent(new Event('input'));  // no need to trigger input event to perform search, since now focusing the element already searches
+    }, 500);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -855,30 +855,35 @@ function resetLegendHighlight(cy)
  */
 function filterElementsAndPad(cy, selector) {
     let padding = 20;
-    let eles = cy.filter(selector);
-    if (eles.length > 0) {
-        const zoomToFit = calculateFitZoom(cy, eles);
-        if (zoomToFit >= 1.0) {
-            // Compute the size of one node, in rendered pixels, at the zoom level that would be required to fit the selected content exactly.
-            const nodeWidthRendered = zoomToFit * extension_settings.timeline.nodeWidth;
-            const nodeHeightRendered = zoomToFit * extension_settings.timeline.nodeHeight;
-            padding = Math.min(nodeWidthRendered, nodeHeightRendered);  // arbitrary, but maybe better than max
-
-            // Limit padding so that at least one node always fits into the viewport, regardless of how far in we try to zoom.
-            // This prevents the graph from zooming out due to an insane theoretical amount of padding (more than viewport size)
-            // when the auto-zoom zooms in really close.
-            //
-            // In practice: if one node would take >= 34% of horizontal or vertical viewport space, reserve 33% of the smaller
-            // viewport dimension for padding on each side, to clamp the size of one node along that dimension to at most 34%.
-            // This limits the size of one node to ~one third of the viewport size.
-            const view_w = cy.width();
-            const view_h = cy.height();
-            if ((nodeWidthRendered >= 0.34 * view_w) || (nodeHeightRendered >= 0.34 * view_h)) {
-                padding = Math.min(0.33 * view_w, 0.33 * view_h);
-            }
-        }
+    let eles;
+    if (!selector) {
+        eles = cy.filter();  // zoom out (select all elements) if no selector (empty query)
     } else {
-        eles = cy.filter();  // zoom out (select all elements) if the selector didn't match
+        eles = cy.filter(selector);
+        if (eles.length > 0) {
+            const zoomToFit = calculateFitZoom(cy, eles);
+            if (zoomToFit >= 1.0) {
+                // Compute the size of one node, in rendered pixels, at the zoom level that would be required to fit the selected content exactly.
+                const nodeWidthRendered = zoomToFit * extension_settings.timeline.nodeWidth;
+                const nodeHeightRendered = zoomToFit * extension_settings.timeline.nodeHeight;
+                padding = Math.min(nodeWidthRendered, nodeHeightRendered);  // arbitrary, but maybe better than max
+
+                // Limit padding so that at least one node always fits into the viewport, regardless of how far in we try to zoom.
+                // This prevents the graph from zooming out due to an insane theoretical amount of padding (more than viewport size)
+                // when the auto-zoom zooms in really close.
+                //
+                // In practice: if one node would take >= 34% of horizontal or vertical viewport space, reserve 33% of the smaller
+                // viewport dimension for padding on each side, to clamp the size of one node along that dimension to at most 34%.
+                // This limits the size of one node to ~one third of the viewport size.
+                const view_w = cy.width();
+                const view_h = cy.height();
+                if ((nodeWidthRendered >= 0.34 * view_w) || (nodeHeightRendered >= 0.34 * view_h)) {
+                    padding = Math.min(0.33 * view_w, 0.33 * view_h);
+                }
+            }
+        } else {
+            eles = cy.filter();  // zoom out (select all elements) if the selector didn't match
+        }
     }
     return [eles, padding]
 }

--- a/tl_graph.js
+++ b/tl_graph.js
@@ -113,7 +113,7 @@ export function highlightNodesByQuery(cy, query, searchMode) {
     // If there's no query, restore elements to their original state.
     if (!query || query === '') {
         restoreElements(cy);
-        return;
+        return undefined;
     }
 
     const queryLowerCase = query.toLowerCase();

--- a/tl_utils.js
+++ b/tl_utils.js
@@ -35,6 +35,11 @@ const saveChatDebounced = debounce(() => getContext().saveChat(), 2000);
  */
 export async function navigateToMessage(chatSessionName, messageId, swipeId = -1, branch = false) {
 
+    // Sanity check (a message might have a null `swipeId`)
+    if (swipeId === null || swipeId === undefined) {
+        swipeId = -1;
+    }
+
     // Remove extension from file name
     chatSessionName = chatSessionName.replace('.jsonl', '');
 
@@ -235,12 +240,18 @@ export function handleModalDisplay() {
  * 5. Emits a 'MESSAGE_SWIPED' event and saves the chat data.
  */
 async function goToSwipe(targetSwipeId) {  // TODO: To avoid duplication, this function could be moved to the main ST frontend?
+    if (targetSwipeId === null || targetSwipeId === undefined) {
+        console.error('Timelines: goToSwipe: Swipe ID not given, cannot go to swipe.');
+        return;
+    }
+
     const context = getContext();
     const chat = context.chat;
     const lastMessageId = chat.length - 1;
     const lastMessageObj = chat[lastMessageId];
 
     // Reset with wraparound if exceeding bounds
+    console.debug(`Timelines: goToSwipe: Asked to switch last message to swipe ${targetSwipeId + 1}.`);
     if (targetSwipeId < 0) {
         targetSwipeId = lastMessageObj['swipes'].length - 1;
     } else if (targetSwipeId >= lastMessageObj['swipes'].length) {
@@ -248,6 +259,7 @@ async function goToSwipe(targetSwipeId) {  // TODO: To avoid duplication, this f
     }
 
     // Set the swipe ID
+    console.debug(`Timelines: goToSwipe: After bounds checking, switching last message to swipe ${targetSwipeId + 1}.`);
     lastMessageObj['swipe_id'] = targetSwipeId;
     console.debug(lastMessageObj);
 


### PR DESCRIPTION
As it says on the tin.

I don't know how I didn't catch this before - maybe it's only some chat files where a message has a null `swipe_id`.

Anyway, fixed, works now.

**EDIT**: *Sneaked in another small bugfix.*

**Changelog**:

- Fix the branch button in the full info panel sometimes creating a broken chat
- Fix exception in Timelines when hitting Esc to close the *Manage chat files* view (of core ST)
- Fix and improve consistentency in handling of zoom to fit (no more uncaught exceptions from this, hopefully)
- UX: Show loading spinner while the timeline view is opening
- UX: Fix incorrect position of root node (especially if the character has lots of chats)